### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
+This project was originally hosted by Code School, who were an offshoot of Envy Labs until earlier this year, when Code School was absorbed by Pluralsight, which immediately changed the scope of the project.  Since it is no longer interactive, there is no active communication between the local repository and the online repository.  All pull requests and commits are still counted, but the steps in between that were tallied to make sure the student was on the right track are no longer in use.
+
+Pluralsight is primarily a one-sided podcast-like site where you follow along watching, but -- like Team Treehouse -- the videos are no longer intertwined with the students' active participation.  This is no longer the case.
+
+The code, itself, is unchanged, but its vector has done so, completely.
+
+The original videos are now hosted on Pluralsight (https://app.pluralsight.com/library/search?q=code%20school), so one <i>can</i> finish projects they had started over at Code School.
+
+###########################
+
+Original README markdown:
+
 Dojo Rules
 ==========
 


### PR DESCRIPTION
Add explanation for switch from Code School to Pluralsight.  Pluralsight will migrate Code School accounts into Pluralsight accounts so none have to start all the way over.  Your skills learned at Code School have automatically been assessed in your Pluralsight profile.